### PR TITLE
feat: 单页面多路由支持

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,8 +4,10 @@
     "comma-dangle": "off",
     "prefer-template": "off",
     "react/jsx-filename-extension": "off",
+    "react/destructuring-assignment": "off",
     "no-console": "off",
     "import/no-unresolved": "off",
-    "no-param-reassign": "off"
+    "no-param-reassign": "off",
+    "import/prefer-default-export": "off"
   }
 }

--- a/src/loadable.js
+++ b/src/loadable.js
@@ -43,12 +43,12 @@ class Pager extends Component {
     }
     loader.then((view) => {
       const store = getStore();
-      const { location, match, args: { retain } } = props;
+      const { location, match, args: { retain, routes } } = props;
       // Component loaded, then dispatch.
       store.dispatch({
         type: updatePage,
         payload: {
-          page, location, match, retain
+          page, location, match, retain, routes
         }
       });
 

--- a/src/reducers/page_updated_reducer.js
+++ b/src/reducers/page_updated_reducer.js
@@ -12,7 +12,7 @@ const hasOwn = Object.prototype.hasOwnProperty;
 
 const matchRetained = ({ url }, state) => {
   const retains = state[r];
-  if (!retains) return;
+  if (!retains) return undefined;
 
   const key = genKey(url);
 
@@ -22,12 +22,10 @@ const matchRetained = ({ url }, state) => {
 const backupPrevState = (state) => {
   const { match: { params, path, url }, page } = prevMatch;
 
-  if (!isNeedRetain(prevMatch.match)) return state;
-
   // siteGuideModel/edit/2066
   const key = genKey(url);
 
-  return produce(state, draft => {
+  return produce(state, (draft) => {
     const retainedData = { data: draft[page], meta: { path, params } };
 
     draft[r] = Object.assign(draft[r] || {}, { [key]: retainedData });
@@ -37,21 +35,18 @@ const backupPrevState = (state) => {
 const restoreNextState = (state, action) => {
   const retainedData = matchRetained(action.payload.match, state);
 
-  return produce(state, draft => {
+  return produce(state, (draft) => {
     if (retainedData) {
       draft[action.payload.page] = retainedData.data;
-    } else {
-      if (isNeedRetain(action.payload.match))
-        draft[action.payload.page] = undefined;
+    } else if (isNeedRetain(action.payload.match)) {
+      draft[action.payload.page] = undefined;
     }
   });
 };
 
 const retainStateReducer = (state, action) => {
-  if (!action.payload.retain)
-    return state;
-  if (!invariant(action.payload.match, 'action\'s payload must has router params!'))
-    return state;
+  if (!action.payload.retain) return state;
+  if (!invariant(action.payload.match, 'action\'s payload must has router params!')) return state;
 
   // match object example:
   //   params: {id: "2066"}

--- a/src/reducers/page_updated_reducer.js
+++ b/src/reducers/page_updated_reducer.js
@@ -6,7 +6,7 @@ const r = '.retained';
 let prevMatch = null;
 
 const isEmptyObj = obj => Object.keys(obj).length === 0;
-const isNeedRetain = m => !isEmptyObj(m.params);
+const isNeedRetain = (multi, routes) => !isEmptyObj(multi.params) || routes;
 const genKey = url => url.substring(1);
 const hasOwn = Object.prototype.hasOwnProperty;
 
@@ -21,6 +21,8 @@ const matchRetained = ({ url }, state) => {
 
 const backupPrevState = (state) => {
   const { match: { params, path, url }, page } = prevMatch;
+
+  if (!isNeedRetain(prevMatch.match, prevMatch.routes)) return state;
 
   // siteGuideModel/edit/2066
   const key = genKey(url);
@@ -38,7 +40,7 @@ const restoreNextState = (state, action) => {
   return produce(state, (draft) => {
     if (retainedData) {
       draft[action.payload.page] = retainedData.data;
-    } else if (isNeedRetain(action.payload.match)) {
+    } else if (isNeedRetain(action.payload.match, action.payload.routes)) {
       draft[action.payload.page] = undefined;
     }
   });
@@ -53,7 +55,11 @@ const retainStateReducer = (state, action) => {
   //   path: "/sizeGuideModel/edit/:id"
   //   url: "/sizeGuideModel/edit/2066"
 
-  const match = { match: action.payload.match, page: action.payload.page };
+  const match = {
+    match: action.payload.match,
+    page: action.payload.page,
+    routes: action.payload.routes
+  };
   if (!prevMatch) {
     prevMatch = match;
     return state;


### PR DESCRIPTION
1. 修复原代码eslint警告；
2. 配合loader，完成单页面多路由支持；
3. 页面组件可通过props.$sense获取当前所在路由，如：
当`me.json`文件中配置了
```json
{
  "route": ["/add", "/edit/:id"]
}
```
则，添加页面`props.$sense === ‘add’`，编辑页面`props.$sense === 'edit'`，可通过该变量，来实现相关页面逻辑处理；
4. 当配置多路由时，多个路由将共用一个state的key下面的状态，所以，建议开启`retain`;
5. 修改原有retain逻辑，当页面url存在参数或者配置多路由的情况下，使用retain。
